### PR TITLE
Closes #3 Error: uninitialized constant ActiveSupport::Autoload

### DIFF
--- a/lib/timespan.rb
+++ b/lib/timespan.rb
@@ -1,3 +1,4 @@
+require 'active_support/dependencies/autoload'
 require 'duration'
 require 'chronic'
 require 'chronic_duration'


### PR DESCRIPTION
As mentioned [here](https://github.com/huydx/facy/issues/17) the issues is fixed by requiring the active_support
autoload before requiring any ActiveSupport extensions.

To me it looks like the issues is in the in the `duration` gem (I had to put the line above `require 'duration'`) but it isn't actively maintained.